### PR TITLE
Changed R distribution configured with nexus proxy CRAN repo URL

### DIFF
--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/vm_config.ps1
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/vm_config.ps1
@@ -54,5 +54,5 @@ local({
     options(repos = r)
 })
 "@
-$RConfig | Out-File -Encoding Ascii ( New-Item -Path $Env:ProgramFiles\R\R-4.1.2\etc\Rprofile.site -Force )
+$RConfig | Out-File -Encoding Ascii ( New-Item -Path $Env:ProgramFiles\R\R-4.2.3\etc\Rprofile.site -Force )
 


### PR DESCRIPTION
# Resolves #19

## What is being addressed

Updates Windows DS VDS image to config CRAN nexus repo with correct R distribution.

## How is this addressed

- Updates R repos config option for R-4.2.3
